### PR TITLE
Adds contributing guide and CoD

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,116 @@
+# Code of Conduct - Perseus Demo Energy
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will
+communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at .
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://contributor-covenant.org/), version
+[1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct/code_of_conduct.md) and
+[2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/code_of_conduct.md),
+and was generated by [contributing-gen](https://github.com/bttger/contributing-gen).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,7 +56,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at .
+reported to the community leaders responsible for enforcement at perseus@ib1.org.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+<!-- omit in toc -->
+
+# Contributing to Perseus Demo Energy
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Asking questions](#asking-questions)
+- [Contributing](#contributing)
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Enhancements](#suggesting-enhancements)
+- [Improving The Documentation](#improving-the-documentation)
+- [Commit Messages](#commit-messages)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Perseus Demo Energy Code of Conduct](https://github.com/icebreakerone/perseus-demo-energyblob/master/CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code. Please report unacceptable behavior
+to [perseus@ib1.org](mailto:perseus@ib1.org).
+
+## Asking questions
+
+### Perseus participants
+
+A slack channel is available for participants buidling prototype for the Perseus trust framework pilot, and is the best place to ask questions. If you are not part of the slack channel, please email [perseus@ib1.org](mailto:perseus@ib1.org)
+
+### Other users
+
+Before you ask a question, it is best to search for existing [Issues](https://github.com/icebreakerone/perseus-demo-energy/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+
+If you then still feel the need to ask a question and need clarification, we recommend the following:
+
+- Open an [Issue](https://github.com/icebreakerone/perseus-demo-energy/issues/new).
+- Provide as much context as you can about what you're running into.
+- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+
+We will then take care of the issue as soon as possible.
+
+## Contributing
+
+> ### Legal Notice <!-- omit in toc -->
+>
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+
+### Reporting Bugs
+
+<!-- omit in toc -->
+
+#### Before Submitting a Bug Report
+
+Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+
+- Make sure that you are using the latest version.
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/icebreakerone/perseus-demo-energy/blob/main/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/icebreakerone/perseus-demo-energyissues?q=label%3Abug).
+- Collect information about the bug:
+- Stack trace (Traceback)
+- OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
+- Version of the interpreter, compiler, SDK, runtime environment, package manager, depending on what seems relevant.
+- Possibly your input and the output
+
+#### How Do I Submit a Good Bug Report?
+
+> Please do not report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs should be sent by email to perseus@ib1.org
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+
+- Open an [Issue](https://github.com/icebreakerone/perseus-demo-energy/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Explain the behavior you would expect and the actual behavior.
+- Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+- Provide the information you collected in the previous section.
+
+Once it's filed, we will label the issue accordingly and work on it as soon as possible.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for Perseus Demo Energy, **including completely new features and minor improvements to existing functionality**.
+
+#### Before Submitting an Enhancement
+
+- Make sure that you are using the latest version.
+- Read the [documentation](https://github.com/icebreakerone/perseus-demo-energy/blob/main/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Perform a [search](https://github.com/icebreakerone/perseus-demo-energy/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+
+#### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/icebreakerone/perseus-demo-energy/issues).
+
+- Use a **clear and descriptive title** for the issue to identify the suggestion.
+- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+- **Describe the current behavior** and **explain which behavior you expected to see instead** and why
+- Provide links to code, if applicable
+
+### Improving The Documentation
+
+Feedback on our documentation is always welcome. If you see something that is wrong, missing, or could be explained better, you can help us by creating an issue, or by creating a pull request with the suggested changes.
+
+## Commit Messages
+
+Commit messages should start with a short summary line a.k.a. message subject:
+
+Start with an imperative present active verb: Add, Drop, Fix, Refactor, Optimize, etc.
+
+Use up to 50 characters; this is the git official preference.
+
+Finish without a full-stop.
+
+Example: `Add CONTRIBUTING.md`
+
+This summary can be followed by a longer description where more detail is needed. You can add as much information as you want here.
+
+## Attribution
+
+This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,17 +23,19 @@ to [perseus@ib1.org](mailto:perseus@ib1.org).
 
 ### Perseus participants
 
-A slack channel is available for participants buidling prototype for the Perseus trust framework pilot, and is the best place to ask questions. If you are not part of the slack channel, please email [perseus@ib1.org](mailto:perseus@ib1.org)
+A slack channel is available for participants building prototypes for the Perseus trust framework pilot, and is the best place to ask questions. If you are not part of the slack channel and wish to have access, please email [perseus@ib1.org](mailto:perseus@ib1.org)
 
 ### Other users
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/icebreakerone/perseus-demo-energy/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/icebreakerone/perseus-demo-energy/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
 - Open an [Issue](https://github.com/icebreakerone/perseus-demo-energy/issues/new).
 - Provide as much context as you can about what you're running into.
-- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+- Provide project and platform versions, depending on what seems relevant.
+- If relevant, include screenshots or error messages.
+- If you have a question about a specific part of the project, please include the link to the file or the line number.
 
 We will then take care of the issue as soon as possible.
 
@@ -52,7 +54,7 @@ We will then take care of the issue as soon as possible.
 Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/icebreakerone/perseus-demo-energy/blob/main/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/icebreakerone/perseus-demo-energy/blob/main/README.md). If you are looking for support, you might want to check [this section](#asking-questions)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/icebreakerone/perseus-demo-energyissues?q=label%3Abug).
 - Collect information about the bug:
 - Stack trace (Traceback)
@@ -82,7 +84,7 @@ This section guides you through submitting an enhancement suggestion for Perseus
 - Make sure that you are using the latest version.
 - Read the [documentation](https://github.com/icebreakerone/perseus-demo-energy/blob/main/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
 - Perform a [search](https://github.com/icebreakerone/perseus-demo-energy/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
-- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+- Find out whether your idea fits with the scope and aims of the project. If you are not sure, feel free to ask in the [slack channel](#asking-questions).
 
 #### How Do I Submit a Good Enhancement Suggestion?
 


### PR DESCRIPTION
I think it's worth adding a contributing guide, I've created this from the boiler plate at https://contributing.md (seems very widely used), editing it for brevity and adding our details. The short version is:

- Enhancements / improvement / bugs as GitHub issues
- Ask or help in the Slack channel
- Security issues via email

Alternatively we could add details of this to the README.md. 

I've included the [code of conduct](https://github.com/icebreakerone/perseus-demo-energy/pull/38/files#diff-ffdbe3a1e7ee93cacfc080b6c635ccf3a8f6b0f00f2fb884f78c6b5f9dac8fd2) from contributing.md without edits, but we might want to leave that out until we have the time to properly review it and invite input from others, or there may be existing content from ib1 code of conduct / membership terms documents that we ought to include