### PR TITLE
oauth-authorization-server endpoint and endpoints

### DIFF
--- a/authentication/.env.template
+++ b/authentication/.env.template
@@ -1,6 +1,6 @@
-OAUTH_CLIENT_ID=XXXXX
-OAUTH_CLIENT_SECRET=XXXXX
-OAUTH_URL=https://custom-domain.projects.oryapis.com
+ORY_CLIENT_ID=XXXXX
+ORY_CLIENT_SECRET=XXXXX
+ORY_URL=https://custom-domain.projects.oryapis.com
 ISSUER_URL=https://localhost:8000
 API_DOMAIN=https://localhost:8000
 JWT_SIGNING_KEY=/certs/jwt-signing-key.pem

--- a/authentication/api/auth.py
+++ b/authentication/api/auth.py
@@ -60,7 +60,6 @@ def create_enhanced_access_token(
     )
     claims["client_id"] = client_id
     private_key = keystores.get_key(conf.JWT_SIGNING_KEY)
-    print(private_key)
     if not isinstance(private_key, ec.EllipticCurvePrivateKey):
         raise TypeError("The private key is not an EllipticCurvePrivateKey")
     return jwt.encode(claims, private_key, algorithm="ES256", headers={"kid": "1"})

--- a/authentication/api/conf.py
+++ b/authentication/api/conf.py
@@ -4,20 +4,26 @@ DIRNAME = os.path.dirname(os.path.realpath(__file__))
 # For our jwks endpoint and signing
 
 
-ISSUER_URL = os.environ.get("ISSUER_URL", "https://perseus-demo-authentication.ib1.org")
+ISSUER_URL = os.environ.get(
+    "ISSUER_URL", "https://perseus-demo-authentication.ib1.org"
+)  # This server, used to generate openid-configuration
 
-OAUTH_CLIENT_SECRET = os.environ.get("OAUTH_CLIENT_SECRET")
-OAUTH_URL = os.environ.get("OAUTH_URL")
-OAUTH_CLIENT_ID = os.environ.get("OAUTH_CLIENT_ID")
-AUTHORIZATION_ENDPOINT = os.environ.get(
-    "AUTHORIZATION_ENDPOINT",
-    f"{OAUTH_URL}/oauth2/auth",
+ORY_CLIENT_SECRET = os.environ.get("ORY_CLIENT_SECRET")  # Ory Hydra Oauth2 client
+ORY_CLIENT_ID = os.environ.get("ORY_CLIENT_ID")  # Ory Hydra Oauth2 client
+ORY_URL = os.environ.get("ORY_URL")  # Ory Hydra Oauth2 server
+ORY_TOKEN_ENDPOINT = (
+    os.environ.get(  # Token issuing is on our side, using the Ory Hydra api
+        "ORY_TOKEN_ENDPOINT",
+        f"{ISSUER_URL}/oauth2/token",
+    )
 )
-TOKEN_ENDPOINT = os.environ.get(
-    "TOKEN_ENDPOINT",
-    f"{OAUTH_URL}/oauth2/token",
+
+ORY_AUTHORIZATION_ENDPOINT = os.environ.get(  # User logins are handled on Ory Hydra
+    "ORY_AUTHORIZATION_ENDPOINT",
+    f"{ORY_URL}/oauth2/auth",
 )
-REDIRECT_URI = os.environ.get(
+
+REDIRECT_URI = os.environ.get(  #
     "REDIRECT_URI", "https://perseus-demo-accounting.ib1.org/callback"
 )
 REDIS_HOST = os.environ.get("REDIS_HOST", "redis")

--- a/authentication/api/examples.py
+++ b/authentication/api/examples.py
@@ -1,20 +1,20 @@
 from pydantic.config import JsonDict
 
 
-OAUTH_CLIENT_ID = "abc123-addefg-4e2f-a8e3-cbd5f6459c30"
+ORY_CLIENT_ID = "abc123-addefg-4e2f-a8e3-cbd5f6459c30"
 
 CLIENT_CERTIFICATE = "-----BEGIN%20CERTIFICATE-----%0AMIIDkzCCAnugAwIBAgIUerCGLrDY6aCYaB6nj9HivLJQtCAwDQYJKoZIhvcNAQEL%0ABQAwVzELMAkGA1UEBhMCR0IxDzANBgNVBAgMBkxvbmRvbjETMBEGA1UECgwKUGVy%0Ac2V1cyBDQTEiMCAGA1UEAwwZcGVyc2V1cy1kZW1vLWZhcGkuaWIxLm9yZzAeFw0y%0ANDAxMzAxNTA2NDRaFw0yNTAxMjkxNTA2NDRaMGwxCzAJBgNVBAYTAkdCMQ8wDQYD%0AVQQIDAZMb25kb24xITAfBgNVBAoMGFBlcnNldXMgRGVtbyBBY2NvdW50YW5jeTEp%0AMCcGA1UEAwwgcGVyc2V1cy1kZW1vLWFjY291bnRhbmN5LmliMS5vcmcwggEiMA0G%0ACSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC06LPNmROgBhDrfpUnfYaoqMENiqcy%0ArbqMGGWiRtRQO87ngL96iCMi30kPQjg4kD8PK49522ZZJ%2BVTqErtD6reS5y6mWkB%0AydsoWRKTi7UyHdyyK9D%2FHc%2FxK1JtFwlAZd4pMaN6KWJLEEfvmZxhOI5pfzKwi6Jj%0A%2BOfedpVJSAeXkI6CYY6qq33KRI4KQau5E7PbzbcNYICvLj1Vhs2bUz8a0tOJG5r8%0A06MCr%2FtteTYMjbb6x3yVlSL3b3LOtj4n8RCYyLlQ3S4ni1MSyHdnqngUGGyrnSVI%0AJF3lR9xJ6AK96RNgiRSzjCWOjOFZjnpuFlGa%2FXxn7buIrDehuKlmVDm3AgMBAAGj%0AQjBAMB0GA1UdDgQWBBRgUt%2BadzZuWnp9bEQLx6qhSm0T%2BTAfBgNVHSMEGDAWgBQP%0Ad2ICahMnEqfEp%2FLCaoBcGQufojANBgkqhkiG9w0BAQsFAAOCAQEArGVkNNfH9Zct%0Ak68YUrky3jPc3L714CjsW3l7yCWCqmkuB6VWIggNqltdKQDzdXDIwFLmN%2Fi7D57K%0AFqDaQboKUumeF3vsIi4LYlRqwGTuN7uGTghcqrpPozM7m%2BYTdPObY%2F8FtL6MqmqJ%0Adv61MYERRl3iLuR6UIbBaQr4YvgThe9WGotqknFOyxrD1yuunlYutOQpF2tXR8hk%0AES5XhvdLQfiuGStM4MPB0%2FWlMwc7mVge5aOVOixJeB0yGNmSSJWeEMQB0ETW3BbF%0AySdR2NroAWqouPWaJMZIpjxldeeTOBmc8k6%2BDLBvRIFcDUgpuLfaoAFTZKtkWbao%0A2NHw6nQAMQ%3D%3D%0A-----END%20CERTIFICATE-----%0A"
 CLIENT_PUSHED_AUTHORIZATION_REQUEST: JsonDict = {
     "response_type": "code",
-    "client_id": OAUTH_CLIENT_ID,
+    "client_id": ORY_CLIENT_ID,
     "redirect_uri": "https://mobile.example.com/cb",
     "code_challenge": "W78hCS0q72DfIHa...kgZkEJuAFaT4",
     "code_challenge_method": "S256",
 }
 
 PUSHED_AUTHORIZATION_REQUEST: JsonDict = {
-    "parameters": f"response_type=code&client_id={OAUTH_CLIENT_ID}&redirect_uri=https%3A%2F%2Fmobile.example.com%2Fcb&code_challenge=W78hCS0q72DfIHa...kgZkEJuAFaT4&code_challenge_method=S256",
-    "client_id": OAUTH_CLIENT_ID,
+    "parameters": f"response_type=code&client_id={ORY_CLIENT_ID}&redirect_uri=https%3A%2F%2Fmobile.example.com%2Fcb&code_challenge=W78hCS0q72DfIHa...kgZkEJuAFaT4&code_challenge_method=S256",
+    "client_id": ORY_CLIENT_ID,
     "client_certificate": CLIENT_CERTIFICATE,
 }
 
@@ -25,7 +25,7 @@ PUSHED_AUTHORIZATION_RESPONSE: JsonDict = {
 }
 
 AUTHORIZATION_REQUEST: JsonDict = {
-    "client_id": OAUTH_CLIENT_ID,
+    "client_id": ORY_CLIENT_ID,
     "request_uri": "urn:ietf:params:oauth:request_uri:UymBrux4ZEMrBRKx9UyKyIm98zpX1cHmAPGAGNofmm4",
 }
 
@@ -36,7 +36,7 @@ AUTHORIZATION_RESPONSE: JsonDict = {
 
 
 TOKEN_REQUEST: JsonDict = {
-    "client_id": OAUTH_CLIENT_ID,
+    "client_id": ORY_CLIENT_ID,
     "parameters": "grant_type=authorization_code&redirect_uri=https://client.example.org/cb/example.com&code=DxiKC0cOc_46nzVjgr41RWBQtMDrAvc0BUbMJ_v7I70",
     "client_certificate": CLIENT_CERTIFICATE,
     "redirect_uri": "https://client.example.org/cb/",
@@ -62,7 +62,7 @@ INTROSPECTION_REQUEST: JsonDict = {
 INTROSPECTION_FAILED_RESPONSE: JsonDict = {"active": False}
 INTROSPECTION_RESPONSE = {
     "aud": [],
-    "client_id": OAUTH_CLIENT_ID,
+    "client_id": ORY_CLIENT_ID,
     "exp": 1713285925,
     "ext": {},
     "iat": 1713282325,

--- a/authentication/api/examples.py
+++ b/authentication/api/examples.py
@@ -2,11 +2,14 @@ from pydantic.config import JsonDict
 
 
 ORY_CLIENT_ID = "abc123-addefg-4e2f-a8e3-cbd5f6459c30"
+DIRECTORY_CLIENT_ID = (
+    "https://registry.core.pilot.trust.ib1.org/scheme/perseus/application/test-suite"
+)
 
 CLIENT_CERTIFICATE = "-----BEGIN%20CERTIFICATE-----%0AMIIDkzCCAnugAwIBAgIUerCGLrDY6aCYaB6nj9HivLJQtCAwDQYJKoZIhvcNAQEL%0ABQAwVzELMAkGA1UEBhMCR0IxDzANBgNVBAgMBkxvbmRvbjETMBEGA1UECgwKUGVy%0Ac2V1cyBDQTEiMCAGA1UEAwwZcGVyc2V1cy1kZW1vLWZhcGkuaWIxLm9yZzAeFw0y%0ANDAxMzAxNTA2NDRaFw0yNTAxMjkxNTA2NDRaMGwxCzAJBgNVBAYTAkdCMQ8wDQYD%0AVQQIDAZMb25kb24xITAfBgNVBAoMGFBlcnNldXMgRGVtbyBBY2NvdW50YW5jeTEp%0AMCcGA1UEAwwgcGVyc2V1cy1kZW1vLWFjY291bnRhbmN5LmliMS5vcmcwggEiMA0G%0ACSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC06LPNmROgBhDrfpUnfYaoqMENiqcy%0ArbqMGGWiRtRQO87ngL96iCMi30kPQjg4kD8PK49522ZZJ%2BVTqErtD6reS5y6mWkB%0AydsoWRKTi7UyHdyyK9D%2FHc%2FxK1JtFwlAZd4pMaN6KWJLEEfvmZxhOI5pfzKwi6Jj%0A%2BOfedpVJSAeXkI6CYY6qq33KRI4KQau5E7PbzbcNYICvLj1Vhs2bUz8a0tOJG5r8%0A06MCr%2FtteTYMjbb6x3yVlSL3b3LOtj4n8RCYyLlQ3S4ni1MSyHdnqngUGGyrnSVI%0AJF3lR9xJ6AK96RNgiRSzjCWOjOFZjnpuFlGa%2FXxn7buIrDehuKlmVDm3AgMBAAGj%0AQjBAMB0GA1UdDgQWBBRgUt%2BadzZuWnp9bEQLx6qhSm0T%2BTAfBgNVHSMEGDAWgBQP%0Ad2ICahMnEqfEp%2FLCaoBcGQufojANBgkqhkiG9w0BAQsFAAOCAQEArGVkNNfH9Zct%0Ak68YUrky3jPc3L714CjsW3l7yCWCqmkuB6VWIggNqltdKQDzdXDIwFLmN%2Fi7D57K%0AFqDaQboKUumeF3vsIi4LYlRqwGTuN7uGTghcqrpPozM7m%2BYTdPObY%2F8FtL6MqmqJ%0Adv61MYERRl3iLuR6UIbBaQr4YvgThe9WGotqknFOyxrD1yuunlYutOQpF2tXR8hk%0AES5XhvdLQfiuGStM4MPB0%2FWlMwc7mVge5aOVOixJeB0yGNmSSJWeEMQB0ETW3BbF%0AySdR2NroAWqouPWaJMZIpjxldeeTOBmc8k6%2BDLBvRIFcDUgpuLfaoAFTZKtkWbao%0A2NHw6nQAMQ%3D%3D%0A-----END%20CERTIFICATE-----%0A"
 CLIENT_PUSHED_AUTHORIZATION_REQUEST: JsonDict = {
     "response_type": "code",
-    "client_id": ORY_CLIENT_ID,
+    "client_id": DIRECTORY_CLIENT_ID,
     "redirect_uri": "https://mobile.example.com/cb",
     "code_challenge": "W78hCS0q72DfIHa...kgZkEJuAFaT4",
     "code_challenge_method": "S256",
@@ -24,10 +27,6 @@ PUSHED_AUTHORIZATION_RESPONSE: JsonDict = {
     "request_uri": "urn:ietf:params:oauth:request_uri:UymBrux4ZEMrBRKx9UyKyIm98zpX1cHmAPGAGNofmm4",
 }
 
-AUTHORIZATION_REQUEST: JsonDict = {
-    "client_id": ORY_CLIENT_ID,
-    "request_uri": "urn:ietf:params:oauth:request_uri:UymBrux4ZEMrBRKx9UyKyIm98zpX1cHmAPGAGNofmm4",
-}
 
 AUTHORIZATION_RESPONSE: JsonDict = {
     "message": "Authorisation code request issued",
@@ -53,24 +52,4 @@ TOKEN_RESPONSE: JsonDict = {
         "o5lPKehvIHyViZgRg4CY_ZGmnyFooG4FCwlZxu-QOTtaDCffCsuCdz4GqknTA"
     ),
     "refresh_token": "tXZjYfoK35I-djg9V3n6s58zsrVqRIzTNMXKIS_wkj8",
-}
-
-INTROSPECTION_REQUEST: JsonDict = {
-    "token": "SUtEVc3Tj3D3xOdysQtssQxe9egAhI4fimexNVMjRyU",
-    "client_certificate": CLIENT_CERTIFICATE,
-}
-INTROSPECTION_FAILED_RESPONSE: JsonDict = {"active": False}
-INTROSPECTION_RESPONSE = {
-    "aud": [],
-    "client_id": ORY_CLIENT_ID,
-    "exp": 1713285925,
-    "ext": {},
-    "iat": 1713282325,
-    "iss": "https://vigorous-heyrovsky-1trvv0ikx9.projects.oryapis.com",
-    "jti": "cca497f5-f3b0-4c81-b873-7f97a74cfcda",
-    "nbf": 1713282325,
-    "scp": ["profile", "offline_access"],
-    "sub": "d6fd6e1c-a10e-40d8-aa2b-9606f3d34d3c",
-    "cnf": {"x5t#S256": "k6Joc_TbRIm_vIQyrWcMTIVz_QZmR0JReGASWRcLdnQ"},
-    "active": True,
 }

--- a/authentication/api/main.py
+++ b/authentication/api/main.py
@@ -277,6 +277,15 @@ async def revoke_token(
     return {"status": "success", "message": "Token revoked"}
 
 
+"""
+Remove subject_types_supported (no OpenID Connect), 
+require_signed_request_object (we don't use JWT signing), 
+scopes_supported (because that's a long list of License URLs) and 
+claims_supported (because we're not doing OpenID Connect and the tokens are opaque)
+
+"""
+
+
 @app.get("/.well-known/oauth-authorization-server")
 async def get_openid_configuration():
     logger.info("Getting Oauth configuration")
@@ -289,12 +298,9 @@ async def get_openid_configuration():
         "jwks_uri": f"{conf.ISSUER_URL}/.well-known/jwks.json",
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token"],
-        "subject_types_supported": ["public"],
         "token_endpoint_auth_methods_supported": ["tls_client_auth"],
         "require_pushed_authorization_requests": True,
         "code_challenge_methods_supported": ["S256"],
-        "scopes_supported": ["openid", "profile", "email"],
-        "claims_supported": ["sub", "client_id", "cnf", "iss", "exp", "iat"],
         "mtls_endpoint_aliases": {
             "authorization_endpoint": f"{conf.ISSUER_URL}/api/v1/authorize",
             "pushed_authorization_request_endpoint": f"{conf.ISSUER_URL}/api/v1/par",
@@ -303,7 +309,6 @@ async def get_openid_configuration():
         },
         "tls_client_certificate_bound_access_tokens": True,
         "authorization_response_iss_parameter_supported": True,
-        "require_signed_request_object": True,
         "request_object_signing_alg_values_supported": ["PS256", "ES256"],
     }
 

--- a/authentication/api/main.py
+++ b/authentication/api/main.py
@@ -301,9 +301,6 @@ async def get_openid_configuration():
             "token_endpoint": f"{conf.ISSUER_URL}/api/v1/authorize/token",
             "revocation_endpoint": f"{conf.ISSUER_URL}/api/v1/authorize/revoke",
         },
-        "fapi_profiles_supported": [
-            "https://openid.net/specs/fapi-2_0-security-profile.html"
-        ],
         "tls_client_certificate_bound_access_tokens": True,
         "authorization_response_iss_parameter_supported": True,
         "require_signed_request_object": True,

--- a/authentication/api/main.py
+++ b/authentication/api/main.py
@@ -277,9 +277,9 @@ async def revoke_token(
     return {"status": "success", "message": "Token revoked"}
 
 
-@app.get("/.well-known/openid-configuration")
+@app.get("/.well-known/oauth-authorization-server")
 async def get_openid_configuration():
-    logger.info("Getting OpenID configuration")
+    logger.info("Getting Oauth configuration")
     return {
         "issuer": conf.ISSUER_URL,
         "authorization_endpoint": f"{conf.ISSUER_URL}/api/v1/authorize",

--- a/authentication/api/models.py
+++ b/authentication/api/models.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel, Field
-from typing import Any
 from . import examples
 
 

--- a/authentication/api/models.py
+++ b/authentication/api/models.py
@@ -45,18 +45,6 @@ class PushedAuthorizationResponse(BaseModel):
     }
 
 
-class AuthorizationRequest(BaseModel):
-    request_uri: str
-    client_id: str
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                examples.AUTHORIZATION_REQUEST,
-            ]
-        }
-    }
-
-
 class AuthorizationResponse(BaseModel):
     """ """
 
@@ -86,93 +74,5 @@ class TokenResponse(BaseModel):
     model_config = {"json_schema_extra": {"examples": [examples.TOKEN_RESPONSE]}}
 
 
-class IntrospectionRequest(BaseModel):
-    token: str
-    client_certificate: str
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                examples.INTROSPECTION_REQUEST,
-            ]
-        }
-    }
-
-
-class IntrospectionFailedResponse(BaseModel):
-    active: bool
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                examples.INTROSPECTION_FAILED_RESPONSE,
-            ]
-        }
-    }
-
-
 class Cnf(BaseModel):
     x5t_S256: str = Field(alias="x5t#S256")
-
-
-class IntrospectionResponse(BaseModel):
-    aud: list[str]
-    client_id: str
-    exp: int
-    ext: dict[str, Any]
-    iat: int
-    iss: str
-    jti: str
-    nbf: int
-    scp: list[str]
-    sub: str
-    cnf: Cnf
-    active: bool
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                {
-                    "aud": [],
-                    "client_id": "f67916ce-de33-4e2f-a8e3-cbd5f6459c30",
-                    "exp": 1713285925,
-                    "ext": {},
-                    "iat": 1713282325,
-                    "iss": "https://vigorous-heyrovsky-1trvv0ikx9.projects.oryapis.com",
-                    "jti": "cca497f5-f3b0-4c81-b873-7f97a74cfcda",
-                    "nbf": 1713282325,
-                    "scp": ["profile", "offline_access"],
-                    "sub": "d6fd6e1c-a10e-40d8-aa2b-9606f3d34d3c",
-                    "cnf": {"x5t#S256": "k6Joc_TbRIm_vIQyrWcMTIVz_QZmR0JReGASWRcLdnQ"},
-                    "active": True,
-                }
-            ]
-        }
-    }
-
-
-# Models for user authentication demo
-
-
-class UserToken(BaseModel):
-    access_token: str
-    token_type: str
-
-
-class UserTokenData(BaseModel):
-    username: str | None = None
-
-
-class User(BaseModel):
-    username: str
-    email: str | None = None
-    full_name: str | None = None
-    disabled: bool | None = None
-
-
-class UserInDB(User):
-    hashed_password: str
-
-
-class Consent(BaseModel):
-    scopes: list[str]
-    model_config = {
-        "json_schema_extra": {"examples": [{"scopes": ["openid", "profile"]}]}
-    }

--- a/authentication/copilot/backend/manifest.yml
+++ b/authentication/copilot/backend/manifest.yml
@@ -40,9 +40,9 @@ network:
 # Optional fields for more advanced use-cases.
 #
 variables:                    # Pass environment variables as key value pairs.
-  OAUTH_CLIENT_ID: f67916ce-de33-4e2f-a8e3-cbd5f6459c30
+  ORY_CLIENT_ID: f67916ce-de33-4e2f-a8e3-cbd5f6459c30
+  ORY_URL: https://vigorous-heyrovsky-1trvv0ikx9.projects.oryapis.com
   REDIS_HOST: redis.${COPILOT_ENVIRONMENT_NAME}.${COPILOT_APPLICATION_NAME}.local
-  OAUTH_URL: https://vigorous-heyrovsky-1trvv0ikx9.projects.oryapis.com
   API_DOMAIN: perseus-demo-authentication.ib1.org
   AWS_DEFAULT_REGION: eu-west-2
   JWT_SIGNING_KEY: /copilot/perseus-demo-authentication/dev/secrets/jwt-signing-key
@@ -55,12 +55,12 @@ environments:
       alias: perseus-demo-authentication.ib1.org
       hosted_zone: Z080590727V6ALTWMJ7N5
     secrets: 
-      OAUTH_CLIENT_SECRET: /copilot/perseus-demo-authentication/prod/secrets/client_secret
+      ORY_CLIENT_SECRET: /copilot/perseus-demo-authentication/prod/secrets/client_secret
     variables:
       JWT_SIGNING_KEY:  /copilot/perseus-demo-authentication/prod/secrets/jwt-signing-key
   dev:
     secrets:
-      OAUTH_CLIENT_SECRET: /copilot/perseus-demo-authentication/dev/secrets/client_secret
+      ORY_CLIENT_SECRET: /copilot/perseus-demo-authentication/dev/secrets/client_secret
     http:
       # Requests to this path will be forwarded to your service.
       # To match all requests you can use the "/" path.

--- a/authentication/tests/test_api.py
+++ b/authentication/tests/test_api.py
@@ -23,12 +23,11 @@ class FakeConf:
         self.ISSUER_URL = os.environ.get(
             "ISSUER_URL", "https://perseus-demo-authentication.ib1.org"
         )
-        self.OAUTH_CLIENT_SECRET = "123abc"
-        self.OAUTH_URL = "https://test-oauth.io"
-        self.OAUTH_CLIENT_ID = "abc-123"
-        self.JWKS_URL = f"{self.OAUTH_URL}/.well-known/jwks.json"
-        self.AUTHORIZATION_ENDPOINT = f"{self.OAUTH_URL}/oauth2/auth"
-        self.TOKEN_ENDPOINT = f"{self.OAUTH_URL}/oauth2/token"
+        self.ORY_CLIENT_SECRET = "123abc"
+        self.ORY_URL = "https://test-oauth.io"
+        self.ORY_CLIENT_ID = "abc-123"
+        self.JWKS_URL = f"{self.ORY_URL}/.well-known/jwks.json"
+        self.ORY_TOKEN_ENDPOINT = f"{self.ORY_URL}/oauth2/token"
         self.REDIRECT_URI = "https://test-accounting.org/callback"
         self.REDIS_HOST = "redis"
 
@@ -113,7 +112,7 @@ def test_token_success(mock_directory, mock_auth):
     """Test a successful token request."""
     responses.add(
         responses.POST,
-        f"{FakeConf().OAUTH_URL}/oauth2/token",
+        f"{FakeConf().ORY_URL}/oauth2/token",
         json={"access_token": MOCK_TOKEN, "refresh_token": MOCK_REFRESH_TOKEN},
         status=200,
     )


### PR DESCRIPTION
- Rationalise variable naming for Ory hydra vs. our own auth endpoints
- Add refresh endpoint
- add revoke endpoint
- Fix openid-configuration so that mtls is specified, along with other changes to align with fapi 2.0