### PR TITLE
Switch aws client certificate name to -leaf

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -19,7 +19,7 @@ server {
         # remote ip and forwarding ip
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Amzn-Mtls-Clientcert $ssl_client_escaped_cert;
+        proxy_set_header X-Amzn-Mtls-Clientcert-Leaf $ssl_client_escaped_cert;
         # # certificate verification information
         # # if the client certificate verified 
         # # will have the value of 'SUCCESS' and 'NONE' otherwise

--- a/resource/api/main.py
+++ b/resource/api/main.py
@@ -52,15 +52,15 @@ def consumption(
     from_date: datetime.date = Query(alias="from"),
     to_date: datetime.date = Query(alias="to"),
     token: HTTPAuthorizationCredentials = Depends(security),
-    x_amzn_mtls_clientcert: Annotated[str | None, Header()] = None,
+    x_amzn_mtls_clientcert_leaf: Annotated[str | None, Header()] = None,
     x_fapi_interaction_id: Annotated[str | None, Header()] = None,
 ):
-    if not x_amzn_mtls_clientcert:
+    if not x_amzn_mtls_clientcert_leaf:
         raise HTTPException(
             status_code=401,
             detail="Client certificate required",
         )
-    cert = directory.parse_cert(x_amzn_mtls_clientcert)
+    cert = directory.parse_cert(x_amzn_mtls_clientcert_leaf)
     try:
         directory.require_role(
             "https://registry.core.ib1.org/scheme/perseus/role/carbon-accounting",
@@ -76,7 +76,7 @@ def consumption(
         # And check the certificate binding
         try:
             decoded, headers = auth.check_token(
-                x_amzn_mtls_clientcert,
+                x_amzn_mtls_clientcert_leaf,
                 token.credentials,
                 x_fapi_interaction_id,
             )


### PR DESCRIPTION
The switch from pass through to verify mode has changed the header that aws uses to pass through the client certificate