### PR TITLE
Deploy Proxy callback URLs #95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Meter listing endpoint /datasources requires mtls and token authentication
-- Missing authentication on datasource listing endpoint
 
 ### Changed
 

--- a/authentication/api/conf.py
+++ b/authentication/api/conf.py
@@ -37,6 +37,9 @@ ORY_AUTHORIZATION_ENDPOINT = (
 REDIRECT_URI = os.environ.get(  #
     "REDIRECT_URI", "https://perseus-demo-accounting.ib1.org/callback"
 )
+CALLBACK_URL = os.environ.get(
+    "CALLBACK_URL", f"{UNPROTECTED_URL}/api/v1/callback"
+)
 REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
 API_DOMAIN = os.environ.get("API_DOMAIN", "perseus-demo-authentication.ib1.org")
 

--- a/authentication/api/main.py
+++ b/authentication/api/main.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 import json
 import os
+from urllib.parse import urlencode, urlparse, urlunparse, parse_qs
 
 from cryptography import x509
 from fastapi import (
@@ -8,6 +9,7 @@ from fastapi import (
     Depends,
     Header,
     HTTPException,
+    Request,
     status,
     Form,
 )
@@ -18,7 +20,7 @@ from fastapi.responses import Response
 from ib1 import directory
 from . import models
 from . import conf
-from . import par
+from . import store
 from . import auth
 from . import permissions
 from . import evidence
@@ -94,8 +96,9 @@ async def pushed_authorization_request(
             {"client_id": client_id}
         ),  # For ory hydra interaction
     }
-    token = par.get_token()
-    par.store_request(token, parameters)
+    token = store.get_token()
+    store.store_request(token, parameters)
+    store.store_callback_url(parameters["state"], redirect_uri)
     return {
         "request_uri": f"urn:ietf:params:oauth:request_uri:{token}",
         "expires_in": 600,
@@ -126,7 +129,7 @@ async def authorize(
         )
     # Retrieve PAR data from Redis
     token = request_uri.split(":")[-1]
-    par_request = par.get_request(token)
+    par_request = store.get_request(token)
     if not par_request:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -137,7 +140,7 @@ async def authorize(
         f"{conf.ORY_AUTHORIZATION_ENDPOINT}?"
         f"client_id={conf.ORY_CLIENT_ID}&"
         f"response_type=code&"
-        f"redirect_uri={par_request['redirect_uri']}&"
+        f"redirect_uri={conf.CALLBACK_URL}&"
         f"scope={par_request['scope']}&"
         f"code_challenge={par_request['code_challenge']}&"
         f"code_challenge_method=S256&"
@@ -147,6 +150,41 @@ async def authorize(
     logger.info(f"Redirecting to {authorization_url}")
     # Redirect the user to the authorization URL
     return Response(status_code=302, headers={"Location": authorization_url})
+
+
+@app.get("/api/v1/callback")
+async def callback(request: Request):
+    """
+    Callback proxy endpoint
+
+    Hydra redirects here after login/consent. We look up the client's
+    original callback URL from Redis (keyed by state) and forward the
+    user there with all query parameters preserved.
+    """
+    params = dict(request.query_params)
+    state = params.get("state")
+    if not state:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing state parameter",
+        )
+
+    original_url = store.get_callback_url(state)
+    if not original_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Callback URL not found or expired for this state",
+        )
+
+    parsed = urlparse(original_url)
+    existing_params = parse_qs(parsed.query, keep_blank_values=True)
+    # Flatten single-value lists from parse_qs
+    merged = {k: v[0] if len(v) == 1 else v for k, v in existing_params.items()}
+    merged.update(params)
+    new_query = urlencode(merged, doseq=True)
+    redirect_url = urlunparse(parsed._replace(query=new_query))
+
+    return Response(status_code=302, headers={"Location": redirect_url})
 
 
 async def parsed_client_cert(
@@ -196,7 +234,7 @@ async def token(
         payload = {
             "grant_type": grant_type,
             "code": code,
-            "redirect_uri": redirect_uri,
+            "redirect_uri": conf.CALLBACK_URL,
             "client_id": conf.ORY_CLIENT_ID,
             "code_verifier": code_verifier,
         }

--- a/authentication/api/store.py
+++ b/authentication/api/store.py
@@ -30,3 +30,14 @@ def get_request(token: str) -> dict | None:
     except json.decoder.JSONDecodeError:
         return None
     return data
+
+
+def store_callback_url(state: str, url: str):
+    connection = redis_connection()
+    connection.set(f"callback:{state}", url)
+    connection.expire(f"callback:{state}", 600)  # 10 minutes
+
+
+def get_callback_url(state: str) -> str | None:
+    connection = redis_connection()
+    return connection.get(f"callback:{state}")

--- a/authentication/tests/test_api.py
+++ b/authentication/tests/test_api.py
@@ -29,10 +29,12 @@ class FakeConf:
         self.ORY_CLIENT_SECRET = "123abc"
         self.ORY_URL = "https://test-oauth.io"
         self.ORY_CLIENT_ID = "abc-123"
+        self.ORY_AUTHORIZATION_ENDPOINT = f"{self.ORY_URL}/oauth2/auth"
         self.JWKS_URL = f"{self.ORY_URL}/.well-known/jwks.json"
         self.JWT_SIGNING_KEY = f"{ROOT_DIR}/fixtures/server-signing-private-key.pem"
         self.ORY_TOKEN_ENDPOINT = f"{self.ORY_URL}/oauth2/token"
         self.REDIRECT_URI = "https://test-accounting.org/callback"
+        self.CALLBACK_URL = "https://perseus-demo-authentication.ib1.org/api/v1/callback"
         self.REDIS_HOST = "redis"
         self.PROVIDER_ROLE = TEST_ROLE
 
@@ -61,10 +63,12 @@ def jwt_signing_jwks():
 
 
 # Mock the redis server, as pushed_authorization_request() uses it
-# @responses.activate
-@patch("api.par.redis_connection")
+@patch("api.store.redis_connection")
+@patch("api.main.store.store_callback_url")
 @patch("api.main.auth.create_state_token")
-def test_pushed_authorization_request(mock_create_state_token, mock_redis_connection):
+def test_pushed_authorization_request(
+    mock_create_state_token, mock_store_callback_url, mock_redis_connection
+):
     cert_urlencoded = client_certificate()
     mock_redis = MagicMock()
     mock_redis.set.return_value = True
@@ -84,9 +88,13 @@ def test_pushed_authorization_request(mock_create_state_token, mock_redis_connec
 
     assert response.status_code == 201
     assert "request_uri" in response.json()
+    mock_store_callback_url.assert_called_once_with(
+        "mock_state_token", "https://mobile.example.com/cb"
+    )
 
 
-@patch("api.par.get_request")
+@patch("api.main.conf", FakeConf())
+@patch("api.store.get_request")
 def test_authorization_code(mock_get_request):
     cert_urlencoded = client_certificate(roles=[TEST_ROLE])
     redirect = "http://anywhere.com"
@@ -108,6 +116,8 @@ def test_authorization_code(mock_get_request):
     )
     assert response.status_code == 302
     assert "Location" in response.headers
+    location = response.headers["Location"]
+    assert f"redirect_uri={FakeConf().CALLBACK_URL}" in location
 
 
 @patch("api.main.conf", FakeConf())
@@ -240,3 +250,44 @@ def test_revoke_token_hydra_error(mock_get_session, mock_revoke_permission):
 
     assert response.status_code == 400
     assert "Invalid token" in response.json()["detail"]
+
+
+@patch("api.main.store.get_callback_url")
+def test_callback_redirects_to_stored_url(mock_get_callback_url):
+    """Test callback endpoint redirects to the original stored URL."""
+    mock_get_callback_url.return_value = "https://mobile.example.com/cb"
+    response = client.get(
+        "/api/v1/callback",
+        params={"code": "auth_code_123", "state": "test_state", "scope": "profile"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    location = response.headers["Location"]
+    assert "mobile.example.com/cb" in location
+    assert "code=auth_code_123" in location
+    assert "state=test_state" in location
+    assert "scope=profile" in location
+
+
+def test_callback_missing_state():
+    """Test callback endpoint returns 400 when state is missing."""
+    response = client.get(
+        "/api/v1/callback",
+        params={"code": "auth_code_123"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 400
+    assert "Missing state" in response.json()["detail"]
+
+
+@patch("api.main.store.get_callback_url")
+def test_callback_expired_state(mock_get_callback_url):
+    """Test callback endpoint returns 400 when state has expired."""
+    mock_get_callback_url.return_value = None
+    response = client.get(
+        "/api/v1/callback",
+        params={"code": "auth_code_123", "state": "expired_state"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 400
+    assert "not found or expired" in response.json()["detail"]


### PR DESCRIPTION
- Use a single callback url to avoid registering new callbacks for each client
- Store clients requested callback urls at PAR stage
- Proxy callback response from Ory