### PR TITLE
Remove cnf thumbprint binding and x-fapi-interaction-id handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v3.0.0] - 2026-06-02
+
+### Added
+
+- OpenAPI security schemes documenting the FAPI authentication: mTLS (`mutualTLS`) and the OAuth2 authorization-code flow on the authentication server, and mTLS plus a certificate-bound bearer token on the resource server, with per-endpoint security requirements
+- Citations to the IB1 Trust Framework specifications (member-identity certificates, OAuth profile, provenance records) in the API documentation
+- `SCHEME_BASE_URL` as a single source of truth for registry/scheme URLs in the authentication app (previously only present in the resource app)
+
+### Changed
+
+- Registry/scheme configuration is now environment-aware: `PROVIDER_ROLE`, `TRUST_FRAMEWORK_URL`, and the OAuth scope derive from `SCHEME_BASE_URL`, wired through CDK per deployment environment (dev → development, prod → core)
+- API docs describe token-to-certificate binding as `client_id` matching the certificate Directory URL, in line with the OAuth profile (rather than `cnf`/`x5t#S256`)
+- Removed the `cnf.x5t#S256` certificate-thumbprint token binding; access tokens are now bound to the client solely via `client_id` matching the certificate Directory URL
+- Removed all `x-fapi-interaction-id` handling (request parameter and response header), as `x-fapi-*` headers are not part of the IB1 OAuth profile
+- Removed the non-standard `transaction` field from provenance transfer steps
+- `messaging.py` derives the trust-framework URL from configuration instead of a hardcoded host
+
+### Fixed
+
+- Corrected provenance records to American `license` spelling, matching the machine-readable registry (previously British `licence`)
+- Corrected the OAuth scope to a valid registry license URL (the previous `energy-consumption-data/2024-12-05` does not exist in the registry)
+
+### Breaking
+
+- Access tokens no longer carry the `cnf.x5t#S256` claim, and the resource server no longer enforces certificate-thumbprint binding (client_id binding only)
+- Protected responses no longer return the `x-fapi-interaction-id` header
+- Provenance transfer steps no longer include the `transaction` field
+- Provenance record field names changed: `licences` → `licenses`, `licence` → `license`, `originLicence` → `originLicense`, altering the signed-record structure
+- OAuth scope / license value changed to `…/scheme/perseus/license/energy-consumption-edp-cap/2026-03-12` (from the previous `energy-consumption-data/2024-12-05` and `scheme/electricity` variants)
+
 ## [v2.0.0] - 2026-02-19
 
 ### Added

--- a/authentication/api/auth.py
+++ b/authentication/api/auth.py
@@ -9,7 +9,6 @@ import jwt
 from jwt import algorithms
 from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives import hashes
 from fastapi import (
     HTTPException,
 )
@@ -60,17 +59,6 @@ def create_state_token(context: dict | None = None) -> str:
     return jwt.encode(payload, private_key, algorithm="ES256")
 
 
-def get_thumbprint(cert: x509.Certificate) -> str:
-    """
-    Returns the thumbprint of a certificate
-    """
-    thumbprint = str(
-        base64.urlsafe_b64encode(cert.fingerprint(hashes.SHA256())).replace(b"=", b""),
-        "utf-8",
-    )
-    return thumbprint
-
-
 def decode_with_jwks(token: str, jwks_url: str) -> dict:
     """
     Validate a token using jwks_url
@@ -96,7 +84,6 @@ def create_enhanced_access_token(
     logger.info("Creating enhanced access token")
     claims = decode_with_jwks(external_token, external_oauth_url)
     logger.info(f"Claims: {claims}")
-    claims["cnf"] = {"x5t#S256": get_thumbprint(client_certificate)}
     claims["iss"] = conf.ISSUER_URL
     client_id = directory.extensions.decode_application(client_certificate)
     claims["client_id"] = client_id

--- a/authentication/api/exceptions.py
+++ b/authentication/api/exceptions.py
@@ -48,10 +48,6 @@ class AccessTokenAudienceError(AccessTokenValidatorError):
     pass
 
 
-class AccessTokenCertificateError(AccessTokenValidatorError):
-    pass
-
-
 class PermissionStorageError(Exception):
     pass
 

--- a/authentication/api/main.py
+++ b/authentication/api/main.py
@@ -270,7 +270,7 @@ async def token(
         raise HTTPException(status_code=response.status_code, detail=response.text)
     result = response.json()
     logger.info(f"Token result: {result}")
-    # Add in our required client certificate thumbprint
+    # Bind the token to the client by setting client_id from the certificate
     enhanced_token = auth.create_enhanced_access_token(
         result["access_token"],
         client_cert,

--- a/authentication/api/models.py
+++ b/authentication/api/models.py
@@ -76,10 +76,6 @@ class TokenResponse(BaseModel):
     model_config = {"json_schema_extra": {"examples": [examples.TOKEN_RESPONSE]}}
 
 
-class Cnf(BaseModel):
-    x5t_S256: str = Field(alias="x5t#S256")
-
-
 class Permission(BaseModel):
     """
     A permission as stored in the DynamoDB table, representing a granted permission

--- a/authentication/tests/test_auth.py
+++ b/authentication/tests/test_auth.py
@@ -16,7 +16,6 @@ from api.auth import (
     create_jwks,
     create_enhanced_access_token,
     encode_jwt,
-    get_thumbprint,
 )
 from tempfile import NamedTemporaryFile
 from api.exceptions import (
@@ -133,6 +132,8 @@ def test_create_enhanced_access_token(mock_get_key, mock_decode_with_jwks):
     decoded_enhanced_token = jwt.decode(
         encoded_token, TEST_PUBLIC_KEY, algorithms=["ES256"]
     )
-    assert "cnf" in decoded_enhanced_token
-    assert "x5t#S256" in decoded_enhanced_token["cnf"]
-    assert decoded_enhanced_token["cnf"]["x5t#S256"] == get_thumbprint(test_certificate)
+    # Token is bound to the client by client_id, not a cnf/x5t#S256 thumbprint.
+    assert "cnf" not in decoded_enhanced_token
+    assert decoded_enhanced_token[
+        "client_id"
+    ] == directory.extensions.decode_application(test_certificate)

--- a/resource/api/auth.py
+++ b/resource/api/auth.py
@@ -1,17 +1,12 @@
-import uuid
-from typing import Optional, Tuple
+from typing import Tuple
 import email.utils
 import time
-import base64
 import ssl
 
-from cryptography.hazmat.primitives import hashes
 import jwt.algorithms
 import jwt
 
-from cryptography import x509
 from .exceptions import (
-    AccessTokenCertificateError,
     AccessTokenAudienceError,
     AccessTokenTimeError,
     AccessTokenDecodingError,
@@ -22,55 +17,6 @@ from ib1 import directory
 from .logger import get_logger
 
 logger = get_logger()
-
-
-def check_certificate(cert: x509.Certificate, decoded_token: dict) -> bool:
-    """
-    Validates the certificate against the thumbprint provided in the decoded token.
-
-    Args:
-        cert (x509.Certificate): The client certificate to be checked.
-        decoded_token (dict): The decoded JWT token containing the certificate thumbprint.
-
-    Raises:
-        AccessTokenCertificateError: If the token does not contain a certificate binding or if the
-                                     thumbprint in the token does not match the presented client certificate.
-
-    Returns:
-        bool: True if the certificate is valid and matches the thumbprint in the token.
-    """
-
-    if "cnf" in decoded_token:
-        # thumbprint from token
-        try:
-            sha256 = decoded_token["cnf"]["x5t#S256"]
-        except KeyError:
-            logger.warning("No x5t#S256 claim in token response, unable to proceed!")
-            raise AccessTokenCertificateError(
-                "Token does not contain a certificate binding"
-            )
-        # thumbprint from presented client certificate
-        fingerprint = str(
-            base64.urlsafe_b64encode(cert.fingerprint(hashes.SHA256())).replace(
-                b"=", b""
-            ),
-            "utf-8",
-        )
-        if fingerprint != sha256:
-            logger.warning(
-                f"Token thumbprint {sha256} does not match "
-                f"presented client cert thumbprint {fingerprint}"
-            )
-            raise AccessTokenCertificateError(
-                "Token certificate binding does not match presented client cert"
-            )
-    else:
-        # No CNF claim in the token
-        logger.warning("No cnf claim in token response, unable to proceed!")
-        raise AccessTokenCertificateError(
-            "Token does not contain a certificate binding"
-        )
-    return True
 
 
 def decode_with_jwks(token: str, jwks_url: str, verify: bytes | None = None) -> dict:
@@ -100,7 +46,6 @@ def decode_with_jwks(token: str, jwks_url: str, verify: bytes | None = None) -> 
 def check_token(
     client_certificate: str,
     token: str,
-    x_fapi_interaction_id: Optional[str] = None,
 ) -> Tuple[dict, dict]:
     """
     Check token is valid if:
@@ -110,7 +55,7 @@ def check_token(
         [ ] has a client_id that matches the MTLS client certificate, and
         [ ] has a scope which matches the required license.
     If check succeeds, return a dict suitable to use as headers
-    including Date and x-fapi-interaction-id, as well as the check token result
+    including Date, as well as the check token result
     """
 
     # Deny access to non-MTLS connections
@@ -129,16 +74,7 @@ def check_token(
         raise AccessTokenTimeError("Token expired")
     if decoded["iat"] > int(time.time()):
         raise AccessTokenTimeError("Token issued in the future")
-    check_certificate(cert, decoded)
     headers = {}
     # FAPI requires that the resource server set the date header in the response
     headers["Date"] = email.utils.formatdate()
-
-    # Get FAPI interaction ID if set, or create a new one otherwise
-    if x_fapi_interaction_id is None:
-        x_fapi_interaction_id = str(uuid.uuid4())
-        logger.debug(f"issuing new interaction ID = {x_fapi_interaction_id}")
-    else:
-        logger.debug(f"using existing interaction ID = {x_fapi_interaction_id}")
-    headers["x-fapi-interaction-id"] = x_fapi_interaction_id
     return decoded, headers

--- a/resource/api/exceptions.py
+++ b/resource/api/exceptions.py
@@ -52,9 +52,5 @@ class AccessTokenAudienceError(AccessTokenValidatorError):
     pass
 
 
-class AccessTokenCertificateError(AccessTokenValidatorError):
-    pass
-
-
 class AccessTokenDecodingError(AccessTokenValidatorError):
     pass

--- a/resource/api/main.py
+++ b/resource/api/main.py
@@ -32,11 +32,6 @@ def require_mtls_and_token(
     request: Request,
     token: HTTPAuthorizationCredentials = Depends(security),
     x_amzn_mtls_clientcert_leaf: Annotated[str | None, Header()] = None,
-    # Hidden from the OpenAPI docs: x-fapi-* headers are not part of the IB1 OAuth
-    # profile. Slated for removal in remove_fapi_interaction_id_plan.md.
-    x_fapi_interaction_id: Annotated[
-        str | None, Header(include_in_schema=False)
-    ] = None,
 ) -> tuple[dict, dict, object]:
     """
     Dependency function that validates MTLS certificate and bearer token.
@@ -84,7 +79,6 @@ def require_mtls_and_token(
             decoded, headers = auth.check_token(
                 cert_pem,
                 token.credentials,
-                x_fapi_interaction_id,
             )
             logger.info("Token validated successfully for sub %s", decoded.get("sub"))
         except AccessTokenValidatorError as e:
@@ -142,7 +136,7 @@ def consumption(
 ):
     if id != DEMO_METER_ID:
         raise HTTPException(status_code=404, detail="Meter not found")
-    decoded, headers, cert = auth_result
+    decoded, _, cert = auth_result
     # Create a new provenance record
     permission_granted = datetime.datetime.now(datetime.timezone.utc)
     permission_expires = datetime.datetime.now(
@@ -155,7 +149,6 @@ def consumption(
         permission_granted=permission_granted,
         account=decoded["sub"],
         service_url=f"https://{conf.API_DOMAIN}/datasources/{id}/{measure}",
-        fapi_id=headers["x-fapi-interaction-id"],
         cap_member=directory.extensions.decode_application(cert),
     )
     with open(f"{conf.ROOT_DIR}/data/sample_data.json") as f:

--- a/resource/api/provenance.py
+++ b/resource/api/provenance.py
@@ -25,7 +25,6 @@ def create_provenance_records(
     permission_expires: datetime.datetime,
     service_url: str,
     account: str,
-    fapi_id: str,
     cap_member: str,
 ) -> bytes:
 
@@ -102,7 +101,6 @@ def create_provenance_records(
                 "to": _date_to_iso(to_date),
             },
             "permissions": [edp_permission_id],
-            "transaction": fapi_id,
         }
     )
 

--- a/resource/tests/fixtures/jwt.json
+++ b/resource/tests/fixtures/jwt.json
@@ -24,8 +24,5 @@
     "iat": 1701358195,
     "iss": "https://auth.directory.sandbox.trust.icebreakerone.org",
     "scope": "directory:software",
-    "cnf": {
-        "x5t#S256": "XCK75zLZH5zm2_bnNfBNxW7UGcvXshgASoJ01T6uVO8"
-    },
     "token_type": "Bearer"
 }

--- a/resource/tests/test_api.py
+++ b/resource/tests/test_api.py
@@ -66,7 +66,7 @@ def test_datasources(
     )
     mock_check_token.return_value = (
         {"sub": "account123"},
-        {"x-fapi-interaction-id": "123"},
+        {"Date": "Mon, 01 Jan 2024 00:00:00 GMT"},
     )
     pem, _, _, _ = client_certificate(
         roles=[conf.PROVIDER_ROLE],
@@ -110,7 +110,7 @@ def test_consumption(
     )
     mock_check_token.return_value = (
         {"sub": "account123"},
-        {"x-fapi-interaction-id": "123"},
+        {"Date": "Mon, 01 Jan 2024 00:00:00 GMT"},
     )
     mock_ib1_directory_get_key.return_value = get_private_key()
     pem, _, _, _ = client_certificate(
@@ -140,6 +140,5 @@ def test_consumption(
         permission_granted=mocker.ANY,
         account="account123",
         service_url=mocker.ANY,
-        fapi_id="123",
         cap_member=mocker.ANY,
     )

--- a/resource/tests/test_auth.py
+++ b/resource/tests/test_auth.py
@@ -84,11 +84,9 @@ def test_missing_kid(mock_jwks):
 @patch("api.auth.decode_with_jwks")
 @patch("api.auth.directory.parse_cert")
 @patch("api.auth.directory.extensions.decode_application")
-@patch("api.auth.check_certificate")
 @patch("api.auth.conf")
 def test_check_token_valid(
     mock_auth_conf,
-    mock_check_certificate,
     mock_decode_application,
     mock_parse_cert,
     mock_decode_with_jwks,
@@ -101,11 +99,6 @@ def test_check_token_valid(
 
     assert decoded == mock_decoded_token
     assert "Date" in headers
-    assert "x-fapi-interaction-id" in headers
-
-    mock_check_certificate.assert_called_once_with(
-        "mocked-parsed-cert", mock_decoded_token
-    )
 
 
 @patch("api.auth.decode_with_jwks")

--- a/resource/tests/test_provenance.py
+++ b/resource/tests/test_provenance.py
@@ -59,7 +59,6 @@ def test_create_provenance_records(
     permission_expires = datetime.datetime(2023, 12, 31, 12, 0, 0)
     service_url = "https://example.com/service"
     account = "account123"
-    fapi_id = "fapi123"
     cap_member = "cap_member123"
 
     # Call the function
@@ -70,7 +69,6 @@ def test_create_provenance_records(
         permission_expires,
         service_url,
         account,
-        fapi_id,
         cap_member,
     )
 


### PR DESCRIPTION
## Summary

Further aligns the implementation with the IB1 Trust Framework specifications by removing two FAPI 2.0 leftovers (follow-up to #97). Tokens are now bound to the client solely via `client_id` matching the certificate Directory URL.

### Removed `cnf.x5t#S256` certificate-thumbprint binding
- `authentication/api/auth.py` — dropped `get_thumbprint()` and the `cnf` claim from `create_enhanced_access_token()`.
- `authentication/api/models.py` — removed the unused `Cnf` model.
- `resource/api/auth.py` — removed `check_certificate()` and its call in `check_token()`.
- `authentication/api/exceptions.py` + `resource/api/exceptions.py` — removed the now-unused `AccessTokenCertificateError`.

### Removed `x-fapi-interaction-id` handling
- `x-fapi-*` headers are not part of the IB1 OAuth profile. Dropped the request parameter, the response header, and the generation block from `resource/api/auth.py` / `resource/api/main.py`.

### Removed provenance `transaction` field
- The non-standard `transaction` field (which carried the interaction id) is not in the Provenance spec; removed from the transfer step in `resource/api/provenance.py` along with the `fapi_id` parameter.

## Breaking changes
- Access tokens no longer carry `cnf.x5t#S256`; the resource server enforces `client_id` binding only.
- Protected responses no longer return `x-fapi-interaction-id`.
- Provenance transfer steps no longer include `transaction`.