### PR TITLE
Update v3.0.0 changelog entry with recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v3.0.0] - 2026-06-02
+## [v3.0.0] - 2026-06-09
 
 ### Added
 
 - OpenAPI security schemes documenting the FAPI authentication: mTLS (`mutualTLS`) and the OAuth2 authorization-code flow on the authentication server, and mTLS plus a certificate-bound bearer token on the resource server, with per-endpoint security requirements
 - Citations to the IB1 Trust Framework specifications (member-identity certificates, OAuth profile, provenance records) in the API documentation
 - `SCHEME_BASE_URL` as a single source of truth for registry/scheme URLs in the authentication app (previously only present in the resource app)
+- Proxy callback URLs: a single registered callback URL serves all clients — each client's requested callback is stored at the PAR stage and the callback response from Ory is proxied back, avoiding per-client callback registration
 
 ### Changed
 
-- Registry/scheme configuration is now environment-aware: `PROVIDER_ROLE`, `TRUST_FRAMEWORK_URL`, and the OAuth scope derive from `SCHEME_BASE_URL`, wired through CDK per deployment environment (dev → development, prod → core)
+- Registry/scheme configuration is now environment-aware: `PROVIDER_ROLE`, `TRUST_FRAMEWORK_URL`, and the OAuth scope derive from `SCHEME_BASE_URL`, wired through CDK per deployment environment (dev → development, prod → sandbox — the prod demo apps run on the sandbox trust framework for testing)
+- Add the Core (development) Trust Framework client CA (root + intermediate) to the dev mTLS trust store, and refresh both the authentication and resource trust stores in `renew_truststores.sh` (each snapshots the shared bundle independently)
 - API docs describe token-to-certificate binding as `client_id` matching the certificate Directory URL, in line with the OAuth profile (rather than `cnf`/`x5t#S256`)
 - Removed the `cnf.x5t#S256` certificate-thumbprint token binding; access tokens are now bound to the client solely via `client_id` matching the certificate Directory URL
 - Removed all `x-fapi-interaction-id` handling (request parameter and response header), as `x-fapi-*` headers are not part of the IB1 OAuth profile
@@ -23,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 - Corrected provenance records to American `license` spelling, matching the machine-readable registry (previously British `licence`)
 - Corrected the OAuth scope to a valid registry license URL (the previous `energy-consumption-data/2024-12-05` does not exist in the registry)
+- Prod CAP role check rejected valid certificates: prod `scheme_base_url` pointed at the core registry, so the expected role (`registry.core.trust.ib1.org/.../carbon-accounting-provider`) did not match the certificates' sandbox-scoped role; corrected prod to the sandbox registry
 
 ### Breaking
 


### PR DESCRIPTION
Folds three changes merged since the v3.0.0 entry was written into that (untagged) entry, and fixes a contradiction:

- **Added**: proxy callback URLs (single registered callback for all clients, stored at PAR and proxied back)
- **Changed**: development client CA added to the dev mTLS trust store + `renew_truststores.sh` refreshes both auth and resource trust stores
- **Changed (correction)**: the `prod → core` line is now `prod → sandbox` — the prod demo apps run on the sandbox trust framework
- **Fixed**: prod CAP role check rejected valid sandbox-scoped certs because prod `scheme_base_url` pointed at the core registry; corrected to sandbox

Date bumped to 2026-06-09 to reflect the folded-in changes. v3.0.0 remains untagged (last tag is v2.0.0).